### PR TITLE
Agregación de librerías para la generación de pdf a Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,15 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # Set work directory
 WORKDIR /app
 
-# Install system dependencies
+# Install system dependencies (including build tools and Cairo for xhtml2pdf/pycairo)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
+    build-essential \
+    pkg-config \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libgdk-pixbuf-xlib-2.0-dev \
+    libffi-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv for fast dependency resolution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "supabase>=2.28.0",
     "google-genai>=1.63.0",
     "python-multipart>=0.0.22",
+    "xhtml2pdf==0.2.17",
+    "jinja2==3.1.6",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
1.
Se han añadido dos librerías (xhtml2pdf versión 0.2.17 & jinja2 versión 3.1.6) para poder generar pdfs. 
Para ello han pasado al final de las dependencias del archivo pyproject.toml:

dependencies = [
    "fastapi>=0.104.1",
    "uvicorn[standard]>=0.24.0",
    "pydantic>=2.5.0",
    "pydantic-settings>=2.1.0",
    "httpx>=0.25.2",
    "python-dotenv>=1.0.0",
    "passlib[bcrypt]>=1.7.4",
    "supabase>=2.28.0",
    "google-genai>=1.63.0",
    "python-multipart>=0.0.22",
    "xhtml2pdf==0.2.17",
    "jinja2==3.1.6",
]

2.
En Dockerfile por otro lado ha habido que agregar paquetes necesarios para compilar pycairo (build-essential, pkg-config, libcairo2-dev, libpango1.0-dev, libgdk-pixbuf-xlib-2.0-dev, libffi-dev). Esto era necesario para que funcionasen las librerías de antes:

# Install system dependencies (including build tools and Cairo for xhtml2pdf/pycairo)
RUN apt-get update && apt-get install -y --no-install-recommends \
    curl \
    build-essential \
    pkg-config \
    libcairo2-dev \
    libpango1.0-dev \
    libgdk-pixbuf-xlib-2.0-dev \
    libffi-dev \
    && rm -rf /var/lib/apt/lists/*

3.
Por último se ha regenerado uv.lock con uv.exe lock